### PR TITLE
use conda-forge for both rdkit and chembl_structure_pipeline

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,9 +1,7 @@
 name: flame
 channels:
   - default
-  - rdkit
   - conda-forge 
-  - chembl
 dependencies:
   - pip
   - python=3.6

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -1,9 +1,7 @@
 name: flame
 channels:
   - default
-  - rdkit
   - conda-forge 
-  - chembl
 dependencies:
   - pip
   - python=3.6


### PR DESCRIPTION
chembl_structure_pipeline's main repository is now conda-forge
The same also applies to RDKit. From Greg's 2021.03.1 release email:

_I do not plan to do conda builds for the Python wrappers in the rdkit channel for this release. The builds done as part of the conda-forge project are automated and cover more Python versions and operating systems than I could ever hope to do manually.
Please install the rdkit using conda-forge: 
conda install -c conda-forge rdkit_
